### PR TITLE
Hide color picker and text editing controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+build/
 .DS_Store
 .env
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+[build]
+  command = "npm run build"
+  publish = "build"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
       },
       "scripts": {
           "dev": "vite",
-          "build": "vite build"
+          "build": "vite build",
+          "preview": "vite preview --host"
       }
   }

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -48,7 +48,7 @@ export function ContactSection() {
         {/* Color Picker Button */}
         <button
           onClick={() => setShowColorPicker(true)}
-          className="absolute top-4 right-4 z-20 p-2 bg-white bg-opacity-20 hover:bg-opacity-30 rounded-full transition-all"
+          className="hidden absolute top-4 right-4 z-20 p-2 bg-white bg-opacity-20 hover:bg-opacity-30 rounded-full transition-all"
           title="Edit Colors"
         >
           <Palette className="w-5 h-5 text-white" />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -33,7 +33,7 @@ export function Footer() {
         {/* Color Picker Button */}
         <button
           onClick={() => setShowColorPicker(true)}
-          className="absolute top-4 right-4 z-20 p-2 bg-white bg-opacity-20 hover:bg-opacity-30 rounded-full transition-all"
+          className="hidden absolute top-4 right-4 z-20 p-2 bg-white bg-opacity-20 hover:bg-opacity-30 rounded-full transition-all"
           title="Edit Colors"
         >
           <Palette className="w-5 h-5 text-white" />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -18,7 +18,7 @@ export function Header() {
         {/* Color Picker Button */}
         <button
           onClick={() => setShowColorPicker(true)}
-          className="absolute top-4 right-4 z-30 p-2 bg-black bg-opacity-10 hover:bg-opacity-20 rounded-full transition-all"
+          className="hidden absolute top-4 right-4 z-30 p-2 bg-black bg-opacity-10 hover:bg-opacity-20 rounded-full transition-all"
           title="Edit Colors"
         >
           <Palette className="w-5 h-5 text-slate-600" />

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -17,7 +17,7 @@ export function HeroSection() {
         {/* Color Picker Button */}
         <button
           onClick={() => setShowColorPicker(true)}
-          className="absolute top-4 right-4 z-20 p-2 bg-black bg-opacity-10 hover:bg-opacity-20 rounded-full transition-all"
+          className="hidden absolute top-4 right-4 z-20 p-2 bg-black bg-opacity-10 hover:bg-opacity-20 rounded-full transition-all"
           title="Edit Colors"
         >
           <Palette className="w-5 h-5 text-slate-600" />

--- a/src/components/MediaSection.tsx
+++ b/src/components/MediaSection.tsx
@@ -43,7 +43,7 @@ export function MediaSection() {
         {/* Color Picker Button */}
         <button
           onClick={() => setShowColorPicker(true)}
-          className="absolute top-4 right-4 z-20 p-2 bg-white bg-opacity-20 hover:bg-opacity-30 rounded-full transition-all"
+          className="hidden absolute top-4 right-4 z-20 p-2 bg-white bg-opacity-20 hover:bg-opacity-30 rounded-full transition-all"
           title="Edit Colors"
         >
           <Palette className="w-5 h-5 text-white" />

--- a/src/components/ResultsSection.tsx
+++ b/src/components/ResultsSection.tsx
@@ -42,7 +42,7 @@ export function ResultsSection() {
         {/* Color Picker Button */}
         <button
           onClick={() => setShowColorPicker(true)}
-          className="absolute top-4 right-4 z-20 p-2 bg-black bg-opacity-10 hover:bg-opacity-20 rounded-full transition-all"
+          className="hidden absolute top-4 right-4 z-20 p-2 bg-black bg-opacity-10 hover:bg-opacity-20 rounded-full transition-all"
           title="Edit Colors"
         >
           <Palette className="w-5 h-5 text-slate-600" />

--- a/src/components/StrategySection.tsx
+++ b/src/components/StrategySection.tsx
@@ -40,7 +40,7 @@ export function StrategySection() {
         {/* Color Picker Button */}
         <button
           onClick={() => setShowColorPicker(true)}
-          className="absolute top-4 right-4 z-20 p-2 bg-black bg-opacity-10 hover:bg-opacity-20 rounded-full transition-all"
+          className="hidden absolute top-4 right-4 z-20 p-2 bg-black bg-opacity-10 hover:bg-opacity-20 rounded-full transition-all"
           title="Edit Colors"
         >
           <Palette className="w-5 h-5 text-slate-600" />

--- a/src/components/TeamSection.tsx
+++ b/src/components/TeamSection.tsx
@@ -26,7 +26,7 @@ export function TeamSection() {
         {/* Color Picker Button */}
         <button
           onClick={() => setShowColorPicker(true)}
-          className="absolute top-4 right-4 z-20 p-2 bg-white bg-opacity-20 hover:bg-opacity-30 rounded-full transition-all"
+          className="hidden absolute top-4 right-4 z-20 p-2 bg-white bg-opacity-20 hover:bg-opacity-30 rounded-full transition-all"
           title="Edit Colors"
         >
           <Palette className="w-5 h-5 text-white" />

--- a/src/components/TextEditingToolbar.tsx
+++ b/src/components/TextEditingToolbar.tsx
@@ -17,7 +17,7 @@ export function TextEditingToolbar() {
   };
 
   return (
-    <div className="fixed top-4 left-1/2 transform -translate-x-1/2 z-50 bg-white border border-gray-200 rounded-lg shadow-lg p-2 flex items-center gap-2">
+    <div className="hidden fixed top-4 left-1/2 transform -translate-x-1/2 z-50 bg-white border border-gray-200 rounded-lg shadow-lg p-2 flex items-center gap-2">
       <Type className="w-5 h-5 text-gray-600" />
       
       <div className="h-6 w-px bg-gray-200" />
@@ -26,7 +26,7 @@ export function TextEditingToolbar() {
         onClick={handleToggleEditing}
         variant={isEditing ? "default" : "outline"}
         size="sm"
-        className="flex items-center gap-2"
+        className="hidden flex items-center gap-2"
       >
         <Edit3 className="w-4 h-4" />
         {isEditing ? 'Exit Editing' : 'Edit Text'}

--- a/src/index.html
+++ b/src/index.html
@@ -219,7 +219,7 @@
     <!-- Header -->
     <header id="header" class="relative z-20" style="background: linear-gradient(to bottom, #f0f9ff, #e0f2fe); border-bottom: 1px solid #bae6fd;">
         <!-- Color Picker Button -->
-        <button onclick="openColorPicker('header')" class="absolute top-4 right-4 z-30 p-2 bg-black bg-opacity-10 hover:bg-opacity-20 rounded-full transition-all" title="Edit Colors">
+        <button onclick="openColorPicker('header')" class="hidden absolute top-4 right-4 z-30 p-2 bg-black bg-opacity-10 hover:bg-opacity-20 rounded-full transition-all" title="Edit Colors">
             <svg class="w-5 h-5 text-slate-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zM7 3V1a1 1 0 011-1h8a1 1 0 011 1v2M7 21h10a2 2 0 002-2v-4a2 2 0 00-2-2H7"></path>
             </svg>
@@ -274,7 +274,7 @@
         <!-- Hero Section -->
         <section id="home" class="relative overflow-hidden py-20" style="background: linear-gradient(to bottom right, #f0f9ff, #e0f2fe);">
             <!-- Color Picker Button -->
-            <button onclick="openColorPicker('hero')" class="absolute top-4 right-4 z-20 p-2 bg-black bg-opacity-10 hover:bg-opacity-20 rounded-full transition-all" title="Edit Colors">
+            <button onclick="openColorPicker('hero')" class="hidden absolute top-4 right-4 z-20 p-2 bg-black bg-opacity-10 hover:bg-opacity-20 rounded-full transition-all" title="Edit Colors">
                 <svg class="w-5 h-5 text-slate-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zM7 3V1a1 1 0 011-1h8a1 1 0 011 1v2M7 21h10a2 2 0 002-2v-4a2 2 0 00-2-2H7"></path>
                 </svg>
@@ -334,7 +334,7 @@
         <!-- Strategy Section -->
         <section id="strategy" class="py-20 relative" style="background: linear-gradient(to bottom right, #f8fafc, #f1f5f9);">
             <!-- Color Picker Button -->
-            <button onclick="openColorPicker('strategy')" class="absolute top-4 right-4 z-20 p-2 bg-black bg-opacity-10 hover:bg-opacity-20 rounded-full transition-all" title="Edit Colors">
+            <button onclick="openColorPicker('strategy')" class="hidden absolute top-4 right-4 z-20 p-2 bg-black bg-opacity-10 hover:bg-opacity-20 rounded-full transition-all" title="Edit Colors">
                 <svg class="w-5 h-5 text-slate-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zM7 3V1a1 1 0 011-1h8a1 1 0 011 1v2M7 21h10a2 2 0 002-2v-4a2 2 0 00-2-2H7"></path>
                 </svg>
@@ -397,7 +397,7 @@
         <!-- Team Section -->
         <section id="team" class="py-20 relative" style="background: linear-gradient(to bottom right, #f0f9ff, #f8fafc);">
             <!-- Color Picker Button -->
-            <button onclick="openColorPicker('team')" class="absolute top-4 right-4 z-20 p-2 bg-black bg-opacity-10 hover:bg-opacity-20 rounded-full transition-all" title="Edit Colors">
+            <button onclick="openColorPicker('team')" class="hidden absolute top-4 right-4 z-20 p-2 bg-black bg-opacity-10 hover:bg-opacity-20 rounded-full transition-all" title="Edit Colors">
                 <svg class="w-5 h-5 text-slate-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zM7 3V1a1 1 0 011-1h8a1 1 0 011 1v2M7 21h10a2 2 0 002-2v-4a2 2 0 00-2-2H7"></path>
                 </svg>
@@ -462,7 +462,7 @@
         <!-- Insights Section -->
         <section id="insights" class="py-20 relative" style="background: linear-gradient(to bottom right, #e0f2fe, #f0f9ff);">
             <!-- Color Picker Button -->
-            <button onclick="openColorPicker('insights')" class="absolute top-4 right-4 z-20 p-2 bg-black bg-opacity-10 hover:bg-opacity-20 rounded-full transition-all" title="Edit Colors">
+            <button onclick="openColorPicker('insights')" class="hidden absolute top-4 right-4 z-20 p-2 bg-black bg-opacity-10 hover:bg-opacity-20 rounded-full transition-all" title="Edit Colors">
                 <svg class="w-5 h-5 text-slate-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zM7 3V1a1 1 0 011-1h8a1 1 0 011 1v2M7 21h10a2 2 0 002-2v-4a2 2 0 00-2-2H7"></path>
                 </svg>
@@ -531,7 +531,7 @@
         <!-- Media Section -->
         <section id="media" class="py-20 relative" style="background: linear-gradient(to bottom right, #f1f5f9, #e0f2fe);">
             <!-- Color Picker Button -->
-            <button onclick="openColorPicker('media')" class="absolute top-4 right-4 z-20 p-2 bg-black bg-opacity-10 hover:bg-opacity-20 rounded-full transition-all" title="Edit Colors">
+            <button onclick="openColorPicker('media')" class="hidden absolute top-4 right-4 z-20 p-2 bg-black bg-opacity-10 hover:bg-opacity-20 rounded-full transition-all" title="Edit Colors">
                 <svg class="w-5 h-5 text-slate-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zM7 3V1a1 1 0 011-1h8a1 1 0 011 1v2M7 21h10a2 2 0 002-2v-4a2 2 0 00-2-2H7"></path>
                 </svg>
@@ -625,7 +625,7 @@
         <!-- Results Section -->
         <section id="results" class="py-20 relative" style="background: linear-gradient(to bottom right, #f0f9ff, #f1f5f9);">
             <!-- Color Picker Button -->
-            <button onclick="openColorPicker('results')" class="absolute top-4 right-4 z-20 p-2 bg-black bg-opacity-10 hover:bg-opacity-20 rounded-full transition-all" title="Edit Colors">
+            <button onclick="openColorPicker('results')" class="hidden absolute top-4 right-4 z-20 p-2 bg-black bg-opacity-10 hover:bg-opacity-20 rounded-full transition-all" title="Edit Colors">
                 <svg class="w-5 h-5 text-slate-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zM7 3V1a1 1 0 011-1h8a1 1 0 011 1v2M7 21h10a2 2 0 002-2v-4a2 2 0 00-2-2H7"></path>
                 </svg>
@@ -709,7 +709,7 @@
         <!-- Contact Section -->
         <section id="contact" class="py-20 relative" style="background: linear-gradient(to bottom right, #e0f2fe, #f8fafc);">
             <!-- Color Picker Button -->
-            <button onclick="openColorPicker('contact')" class="absolute top-4 right-4 z-20 p-2 bg-black bg-opacity-10 hover:bg-opacity-20 rounded-full transition-all" title="Edit Colors">
+            <button onclick="openColorPicker('contact')" class="hidden absolute top-4 right-4 z-20 p-2 bg-black bg-opacity-10 hover:bg-opacity-20 rounded-full transition-all" title="Edit Colors">
                 <svg class="w-5 h-5 text-slate-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zM7 3V1a1 1 0 011-1h8a1 1 0 011 1v2M7 21h10a2 2 0 002-2v-4a2 2 0 00-2-2H7"></path>
                 </svg>
@@ -964,7 +964,7 @@
             const toolbar = document.getElementById('textEditingToolbar');
             const editButton = document.createElement('button');
             editButton.innerHTML = 'Edit Text';
-            editButton.className = 'fixed bottom-4 right-4 z-50 bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition-colors';
+            editButton.className = 'hidden fixed bottom-4 right-4 z-50 bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition-colors';
             editButton.onclick = toggleEditingMode;
             document.body.appendChild(editButton);
 


### PR DESCRIPTION
## Summary
- hide the palette trigger buttons across section components and the static HTML fallback
- hide the text editing toolbar toggle so editing controls no longer appear by default

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2945e38008320aec7e9c95c8bdc7b