### PR TITLE
Add routing and detail views for insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,16 @@
 
   Run `npm i` to install the dependencies.
 
-  Run `npm run dev` to start the development server.
+Run `npm run dev` to start the development server.
+
+## Managing insight articles
+
+1. Open the site in edit mode with the on-page toolbar and update the insight cards. Each article now stores:
+   - `slug` – the stable URL identifier used for the detail page (for example `future-of-b2b-saas`).
+   - `excerpt` – the short summary surfaced on the cards and index pages.
+   - `content` – the full body copy that renders on the dedicated article page. Line breaks are preserved.
+2. To add a new article, use the editing toolbar to duplicate an existing insight card, update the fields above, and adjust the publication metadata (category, date, read time).
+3. Editors can review long-form articles at `/insights/:slug` and browse the paginated archive at `/insights`.
+
+The new fields are saved to local storage, so published changes persist between sessions without requiring code updates.
   

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.55.0",
         "react-resizable-panels": "^2.1.7",
+        "react-router-dom": "^6.23.1",
         "recharts": "^2.15.2",
         "sonner": "^2.0.3",
         "tailwind-merge": "*",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
           "react-dom": "^18.3.1",
           "react-hook-form": "^7.55.0",
           "react-resizable-panels": "^2.1.7",
+          "react-router-dom": "^6.23.1",
           "recharts": "^2.15.2",
           "sonner": "^2.0.3",
           "tailwind-merge": "*",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,31 @@
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+
 import { Header } from "./components/Header";
-import { HeroSection } from "./components/HeroSection";
-import { StrategySection } from "./components/StrategySection";
-import { TeamSection } from "./components/TeamSection";
-import { InsightsSection } from "./components/InsightsSection";
-import { MediaSection } from "./components/MediaSection";
-import { ResultsSection } from "./components/ResultsSection";
-import { ContactSection } from "./components/ContactSection";
 import { Footer } from "./components/Footer";
 import { SectionColorProvider } from "./components/SectionColorProvider";
 import { TextContentProvider } from "./components/TextContentProvider";
 import { TextEditingToolbar } from "./components/TextEditingToolbar";
+import { HomePage } from "./pages/HomePage";
+import { InsightArticlePage } from "./pages/InsightArticlePage";
+import { AllInsightsPage } from "./pages/AllInsightsPage";
 
 export default function App() {
   return (
-    <TextContentProvider>
-      <SectionColorProvider>
-        <div className="min-h-screen bg-white">
-          <TextEditingToolbar />
-          <Header />
-          <main>
-            <HeroSection />
-            <StrategySection />
-            <TeamSection />
-            <InsightsSection />
-            <MediaSection />
-            <ResultsSection />
-            <ContactSection />
-          </main>
-          <Footer />
-        </div>
-      </SectionColorProvider>
-    </TextContentProvider>
+    <BrowserRouter>
+      <TextContentProvider>
+        <SectionColorProvider>
+          <div className="min-h-screen bg-white flex flex-col">
+            <TextEditingToolbar />
+            <Header />
+            <Routes>
+              <Route path="/" element={<HomePage />} />
+              <Route path="/insights" element={<AllInsightsPage />} />
+              <Route path="/insights/:slug" element={<InsightArticlePage />} />
+            </Routes>
+            <Footer />
+          </div>
+        </SectionColorProvider>
+      </TextContentProvider>
+    </BrowserRouter>
   );
 }

--- a/src/components/InsightsSection.tsx
+++ b/src/components/InsightsSection.tsx
@@ -1,10 +1,12 @@
 import { Calendar, ArrowRight } from "lucide-react";
+import { Link } from "react-router-dom";
+
 import { Button } from "./ui/button";
 import { EditableText } from "./EditableText";
 import { useTextContent } from "./TextContentProvider";
 
 export function InsightsSection() {
-  const { textContent } = useTextContent();
+  const { textContent, isEditing } = useTextContent();
   const insights = textContent.insights.articles;
 
   return (
@@ -33,50 +35,64 @@ export function InsightsSection() {
 
         <div className="grid md:grid-cols-3 gap-8">
           {insights.map((insight, index) => (
-            <article key={index} className="bg-slate-50 rounded-lg p-8 hover:shadow-lg transition-shadow cursor-pointer border border-slate-200">
-              <EditableText
-                path={`insights.articles.${index}.category`}
-                value={insight.category}
-                className="text-caption mb-3 uppercase tracking-wide"
-                style={{color: 'var(--blue-corporate)'}}
-              />
-              <EditableText
-                path={`insights.articles.${index}.title`}
-                value={insight.title}
-                as="h3"
-                className="text-card-title text-slate-900 mb-3"
-              />
-              <EditableText
-                path={`insights.articles.${index}.excerpt`}
-                value={insight.excerpt}
-                as="p"
-                className="text-body text-slate-600 mb-6"
-                multiline
-              />
-              
-              <div className="flex items-center justify-between text-caption text-slate-500">
-                <div className="flex items-center">
-                  <Calendar className="w-4 h-4 mr-2" />
-                  <EditableText
-                    path={`insights.articles.${index}.date`}
-                    value={insight.date}
-                  />
+            <Link
+              key={insight.slug || index}
+              to={isEditing ? "#" : `/insights/${insight.slug}`}
+              onClick={event => {
+                if (isEditing) {
+                  event.preventDefault();
+                }
+              }}
+              className="group block"
+            >
+              <article className="bg-slate-50 rounded-lg p-8 hover:shadow-lg transition-shadow cursor-pointer border border-slate-200">
+                <EditableText
+                  path={`insights.articles.${index}.category`}
+                  value={insight.category}
+                  className="text-caption mb-3 uppercase tracking-wide"
+                  style={{ color: 'var(--blue-corporate)' }}
+                />
+                <EditableText
+                  path={`insights.articles.${index}.title`}
+                  value={insight.title}
+                  as="h3"
+                  className="text-card-title text-slate-900 mb-3 group-hover:text-indigo-700 transition-colors"
+                />
+                <EditableText
+                  path={`insights.articles.${index}.excerpt`}
+                  value={insight.excerpt}
+                  as="p"
+                  className="text-body text-slate-600 mb-6"
+                  multiline
+                />
+
+                <div className="flex items-center justify-between text-caption text-slate-500">
+                  <div className="flex items-center">
+                    <Calendar className="w-4 h-4 mr-2" />
+                    <EditableText
+                      path={`insights.articles.${index}.date`}
+                      value={insight.date}
+                    />
+                  </div>
+                  <div className="flex items-center gap-2 text-slate-400 group-hover:text-indigo-600 transition-colors">
+                    <EditableText
+                      path={`insights.articles.${index}.readTime`}
+                      value={insight.readTime}
+                    />
+                    <ArrowRight className="w-4 h-4" />
+                  </div>
                 </div>
-                <div>
-                  <EditableText
-                    path={`insights.articles.${index}.readTime`}
-                    value={insight.readTime}
-                  />
-                </div>
-              </div>
-            </article>
+              </article>
+            </Link>
           ))}
         </div>
 
         <div className="text-center mt-12">
-          <Button variant="outline">
-            View All Insights
-            <ArrowRight className="w-4 h-4 ml-2" />
+          <Button variant="outline" asChild>
+            <Link to="/insights">
+              View All Insights
+              <ArrowRight className="w-4 h-4 ml-2" />
+            </Link>
           </Button>
         </div>
       </div>

--- a/src/components/TextContentProvider.tsx
+++ b/src/components/TextContentProvider.tsx
@@ -79,11 +79,13 @@ export interface TextContent {
     title: string;
     description: string;
     articles: {
+      slug: string;
       title: string;
       excerpt: string;
       date: string;
       readTime: string;
       category: string;
+      content: string;
     }[];
   };
   
@@ -278,25 +280,43 @@ const defaultTextContent: TextContent = {
     description: "Stay informed with our latest market analysis, industry insights, and thought leadership on technology investment trends.",
     articles: [
       {
+        slug: "future-of-b2b-saas",
         title: "The Future of B2B SaaS: Trends Shaping 2024",
         excerpt: "Exploring the key trends that will define the B2B software landscape, from AI integration to evolving customer expectations.",
         date: "March 15, 2024",
         readTime: "5 min read",
-        category: "Market Analysis"
+        category: "Market Analysis",
+        content: `B2B SaaS continues to outpace broader software growth, but the definition of a best-in-class platform is shifting. Customers now expect modular products that integrate natively with existing workflows, along with transparent pricing models that scale with the value delivered.
+
+Artificial intelligence has moved from experimentation to expectation. Winning platforms are embedding AI copilots that augment human decision-making, automate routine processes, and surface predictive insights. At the same time, go-to-market teams are using product-led strategies to shorten sales cycles and reduce acquisition costs.
+
+For operators, the priority is building resilient revenue engines. That means investing in data infrastructure, usage analytics, and customer success motions that deliver measurable outcomes. As budgets tighten, SaaS companies that can prove time-to-value and align pricing with realized savings will capture the lion's share of growth in 2024 and beyond.`
       },
       {
+        slug: "operational-excellence-high-growth-startups",
         title: "Operational Excellence in High-Growth Startups",
         excerpt: "How portfolio companies can maintain operational efficiency while scaling rapidly in competitive markets.",
-        date: "March 8, 2024", 
+        date: "March 8, 2024",
         readTime: "7 min read",
-        category: "Operations"
+        category: "Operations",
+        content: `Growth without guardrails can quickly erode enterprise value. High-performing startups establish operating cadences that create visibility across product, sales, finance, and people functions. Weekly KPI reviews, quarterly planning rituals, and real-time dashboards keep teams aligned on the metrics that matter.
+
+Leaders should invest early in middle management and empower operators closest to the work to make informed decisions. Standardizing processes—from onboarding to incident response—ensures new hires are productive faster and that institutional knowledge is preserved as the team scales.
+
+Finally, disciplined resource allocation is the hallmark of operational excellence. Scenario-based budgeting, zero-based planning, and post-investment reviews help leadership teams redeploy capital toward the initiatives with the highest strategic and financial return.`
       },
       {
+        slug: "esg-integration-private-equity",
         title: "ESG Integration in Private Equity",
         excerpt: "Best practices for incorporating environmental, social, and governance factors into investment decisions.",
         date: "February 28, 2024",
         readTime: "6 min read",
-        category: "ESG"
+        category: "ESG",
+        content: `Institutional investors increasingly expect private equity managers to articulate how environmental, social, and governance factors inform investment selection and value creation plans. Rather than a compliance exercise, leading firms embed ESG metrics into their underwriting models and track progress alongside financial KPIs.
+
+During diligence, investors should evaluate supply-chain resilience, data privacy practices, workforce engagement, and exposure to regulatory change. Post-close, portfolio companies benefit from clear 100-day plans that assign responsibility for ESG initiatives and establish measurement frameworks.
+
+Transparent reporting closes the loop. Quarterly board materials that highlight emissions intensity, diversity metrics, and governance milestones help management teams course-correct quickly while giving LPs confidence that ESG commitments are delivering tangible results.`
       }
     ]
   },

--- a/src/pages/AllInsightsPage.tsx
+++ b/src/pages/AllInsightsPage.tsx
@@ -1,0 +1,131 @@
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { Calendar, Clock, ArrowRight, ChevronLeft, ChevronRight } from "lucide-react";
+
+import { useTextContent } from "../components/TextContentProvider";
+import { EditableText } from "../components/EditableText";
+import { Button } from "../components/ui/button";
+
+const ITEMS_PER_PAGE = 6;
+
+export function AllInsightsPage() {
+  const { textContent, isEditing } = useTextContent();
+  const [page, setPage] = useState(1);
+
+  const articles = textContent.insights.articles;
+  const totalPages = Math.max(1, Math.ceil(articles.length / ITEMS_PER_PAGE));
+
+  const currentPageArticles = useMemo(() => {
+    const start = (page - 1) * ITEMS_PER_PAGE;
+    return articles.slice(start, start + ITEMS_PER_PAGE);
+  }, [articles, page]);
+
+  const handleChangePage = (nextPage: number) => {
+    setPage(Math.min(Math.max(nextPage, 1), totalPages));
+  };
+
+  return (
+    <main className="py-16 sm:py-24 bg-slate-100">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-16 space-y-4">
+          <EditableText
+            path="insights.title"
+            value={textContent.insights.title}
+            as="h1"
+            className="text-4xl sm:text-5xl font-semibold text-slate-900"
+          />
+          <EditableText
+            path="insights.description"
+            value={textContent.insights.description}
+            as="p"
+            className="text-lg text-slate-600 max-w-3xl mx-auto"
+            multiline
+          />
+          <p className="text-sm text-slate-500 max-w-2xl mx-auto">
+            Add new articles directly from the editing toolbar. Each entry needs
+            a unique slug, short excerpt, and the full body content so it can be
+            displayed here and on the detail page.
+          </p>
+        </div>
+
+        <div className="grid gap-8 md:grid-cols-2">
+          {currentPageArticles.map((insight, index) => {
+            const globalIndex = (page - 1) * ITEMS_PER_PAGE + index;
+            return (
+              <Link
+                key={insight.slug || globalIndex}
+                to={isEditing ? "#" : `/insights/${insight.slug}`}
+                onClick={(event) => {
+                  if (isEditing) {
+                    event.preventDefault();
+                  }
+                }}
+                className="group block bg-white rounded-xl shadow-sm hover:shadow-lg transition-shadow border border-slate-200 p-8"
+              >
+                <EditableText
+                  path={`insights.articles.${globalIndex}.category`}
+                  value={insight.category}
+                  className="text-xs font-semibold uppercase tracking-wide text-indigo-600 mb-3"
+                />
+                <EditableText
+                  path={`insights.articles.${globalIndex}.title`}
+                  value={insight.title}
+                  as="h2"
+                  className="text-2xl font-semibold text-slate-900 mb-3 group-hover:text-indigo-700 transition-colors"
+                />
+                <EditableText
+                  path={`insights.articles.${globalIndex}.excerpt`}
+                  value={insight.excerpt}
+                  as="p"
+                  className="text-base text-slate-600 mb-6"
+                  multiline
+                />
+                <div className="flex flex-wrap items-center justify-between text-sm text-slate-500">
+                  <span className="flex items-center gap-2">
+                    <Calendar className="w-4 h-4" />
+                    <EditableText
+                      path={`insights.articles.${globalIndex}.date`}
+                      value={insight.date}
+                    />
+                  </span>
+                  <span className="flex items-center gap-2">
+                    <Clock className="w-4 h-4" />
+                    <EditableText
+                      path={`insights.articles.${globalIndex}.readTime`}
+                      value={insight.readTime}
+                    />
+                  </span>
+                  <span className="flex items-center gap-2 text-slate-400 group-hover:text-indigo-600 transition-colors">
+                    Read insight <ArrowRight className="w-4 h-4" />
+                  </span>
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+
+        <div className="flex items-center justify-between mt-12">
+          <Button
+            variant="outline"
+            onClick={() => handleChangePage(page - 1)}
+            disabled={page === 1}
+            className="flex items-center gap-2"
+          >
+            <ChevronLeft className="w-4 h-4" /> Previous
+          </Button>
+          <p className="text-sm text-slate-500">
+            Page {page} of {totalPages}
+          </p>
+          <Button
+            variant="outline"
+            onClick={() => handleChangePage(page + 1)}
+            disabled={page === totalPages}
+            className="flex items-center gap-2"
+          >
+            Next <ChevronRight className="w-4 h-4" />
+          </Button>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,0 +1,21 @@
+import { HeroSection } from "../components/HeroSection";
+import { StrategySection } from "../components/StrategySection";
+import { TeamSection } from "../components/TeamSection";
+import { InsightsSection } from "../components/InsightsSection";
+import { MediaSection } from "../components/MediaSection";
+import { ResultsSection } from "../components/ResultsSection";
+import { ContactSection } from "../components/ContactSection";
+
+export function HomePage() {
+  return (
+    <main>
+      <HeroSection />
+      <StrategySection />
+      <TeamSection />
+      <InsightsSection />
+      <MediaSection />
+      <ResultsSection />
+      <ContactSection />
+    </main>
+  );
+}

--- a/src/pages/InsightArticlePage.tsx
+++ b/src/pages/InsightArticlePage.tsx
@@ -1,0 +1,110 @@
+import { Link, useParams } from "react-router-dom";
+import { Calendar, Clock, ArrowLeft } from "lucide-react";
+import { useMemo } from "react";
+
+import { useTextContent } from "../components/TextContentProvider";
+import { EditableText } from "../components/EditableText";
+import { Button } from "../components/ui/button";
+
+export function InsightArticlePage() {
+  const { slug } = useParams<{ slug: string }>();
+  const { textContent } = useTextContent();
+
+  const { article, index } = useMemo(() => {
+    const idx = textContent.insights.articles.findIndex(
+      (item) => item.slug === slug,
+    );
+
+    return {
+      article: idx >= 0 ? textContent.insights.articles[idx] : undefined,
+      index: idx,
+    };
+  }, [slug, textContent.insights.articles]);
+
+  if (!article || index < 0) {
+    return (
+      <main className="py-24 px-4">
+        <div className="max-w-3xl mx-auto text-center space-y-6">
+          <h1 className="text-4xl font-semibold text-slate-900">
+            Insight not found
+          </h1>
+          <p className="text-lg text-slate-600">
+            We couldn’t find the article you were looking for. It may have been
+            unpublished or the link may be outdated.
+          </p>
+          <div className="flex flex-wrap gap-4 justify-center">
+            <Button asChild>
+              <Link to="/">Return home</Link>
+            </Button>
+            <Button variant="outline" asChild>
+              <Link to="/insights">Browse all insights</Link>
+            </Button>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="py-16 sm:py-24 bg-slate-50">
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="mb-10">
+          <Button variant="ghost" className="pl-0" asChild>
+            <Link to="/insights">
+              <ArrowLeft className="w-4 h-4 mr-2" /> Back to insights
+            </Link>
+          </Button>
+        </div>
+        <EditableText
+          path={`insights.articles.${index}.category`}
+          value={article.category}
+          className="text-sm uppercase tracking-wide text-indigo-600"
+        />
+        <div className="text-xs uppercase tracking-wide text-slate-400 mb-2">URL Slug</div>
+        <EditableText
+          path={`insights.articles.${index}.slug`}
+          value={article.slug}
+          className="text-sm font-mono text-slate-500 mb-6"
+        />
+        <EditableText
+          path={`insights.articles.${index}.title`}
+          value={article.title}
+          as="h1"
+          className="text-4xl sm:text-5xl font-semibold text-slate-900 mb-6"
+        />
+        <EditableText
+          path={`insights.articles.${index}.excerpt`}
+          value={article.excerpt}
+          as="p"
+          className="text-xl text-slate-600 mb-8"
+          multiline
+        />
+        <div className="flex flex-wrap items-center gap-6 text-sm text-slate-500 mb-12">
+          <span className="flex items-center gap-2">
+            <Calendar className="w-4 h-4" />
+            <EditableText
+              path={`insights.articles.${index}.date`}
+              value={article.date}
+              className="text-sm"
+            />
+          </span>
+          <span className="flex items-center gap-2">
+            <Clock className="w-4 h-4" />
+            <EditableText
+              path={`insights.articles.${index}.readTime`}
+              value={article.readTime}
+              className="text-sm"
+            />
+          </span>
+        </div>
+        <EditableText
+          path={`insights.articles.${index}.content`}
+          value={article.content}
+          as="div"
+          className="prose prose-lg max-w-none text-slate-700 whitespace-pre-line"
+          multiline
+        />
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- extend the text content provider with persistent slugs and full article bodies for each insight
- install client-side routing, wrap the app with BrowserRouter, and add new home, insight detail, and full insights index pages
- update the insights section to link to detailed articles and document how editors can publish new insights without code changes

## Testing
- npm run build *(fails: vite binary unavailable until dependencies are installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e3af4936508320931dc5e6bb902708