### PR TITLE
Update media coverage links and cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,20 @@
 
   Run `npm i` to install the dependencies.
 
-  Run `npm run dev` to start the development server.
+Run `npm run dev` to start the development server.
+
+## Managing insights content
+
+Insight cards and article pages are powered by the editable content in `TextContentProvider`. To publish a new article without touching the components:
+
+1. Open `src/components/TextContentProvider.tsx` and locate the `insights.articles` array.
+2. Duplicate one of the existing entries and update the fields:
+   - `slug`: a URL-safe identifier used in the route (e.g., `"future-of-b2b-saas"`).
+   - `title`: the article headline shown on cards and the detail page.
+   - `excerpt`: the short summary displayed on the insights grid.
+   - `content`: the full body copy for the article. Separate paragraphs with blank lines to preserve spacing.
+   - `date`, `readTime`, and `category`: metadata displayed on both the card and article header.
+3. Save the file. When editors toggle edit mode in the CMS toolbar, they can fine-tune all of the copy directly on the site; changes persist in local storage.
+
+Adding a new object to this array automatically creates a new `/insights/<slug>` route that renders the long-form article.
   

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
           "react": "^18.3.1",
           "react-day-picker": "^8.10.1",
           "react-dom": "^18.3.1",
+          "react-router-dom": "^6.28.0",
           "react-hook-form": "^7.55.0",
           "react-resizable-panels": "^2.1.7",
           "recharts": "^2.15.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { Outlet, Route, Routes } from "react-router-dom";
 import { Header } from "./components/Header";
 import { HeroSection } from "./components/HeroSection";
 import { TeamSection } from "./components/TeamSection";
@@ -10,25 +11,45 @@ import { Footer } from "./components/Footer";
 import { SectionColorProvider } from "./components/SectionColorProvider";
 import { TextContentProvider } from "./components/TextContentProvider";
 import { TextEditingToolbar } from "./components/TextEditingToolbar";
+import { InsightArticlePage } from "./pages/InsightArticlePage";
+
+function Layout() {
+  return (
+    <div className="min-h-screen bg-white">
+      <TextEditingToolbar />
+      <Header />
+      <main>
+        <Outlet />
+      </main>
+      <Footer />
+    </div>
+  );
+}
+
+function HomePage() {
+  return (
+    <>
+      <HeroSection />
+      <TeamSection />
+      <StrategySection />
+      <InsightsSection />
+      <MediaSection />
+      <ResultsSection />
+      <ContactSection />
+    </>
+  );
+}
 
 export default function App() {
   return (
     <TextContentProvider>
       <SectionColorProvider>
-        <div className="min-h-screen bg-white">
-          <TextEditingToolbar />
-          <Header />
-          <main>
-            <HeroSection />
-            <TeamSection />
-            <StrategySection />
-            <InsightsSection />
-            <MediaSection />
-            <ResultsSection />
-            <ContactSection />
-          </main>
-          <Footer />
-        </div>
+        <Routes>
+          <Route element={<Layout />}>
+            <Route index element={<HomePage />} />
+            <Route path="insights/:slug" element={<InsightArticlePage />} />
+          </Route>
+        </Routes>
       </SectionColorProvider>
     </TextContentProvider>
   );

--- a/src/components/InsightsSection.tsx
+++ b/src/components/InsightsSection.tsx
@@ -1,10 +1,11 @@
 import { Calendar, ArrowRight } from "lucide-react";
+import { Link } from "react-router-dom";
 import { Button } from "./ui/button";
 import { EditableText } from "./EditableText";
 import { useTextContent } from "./TextContentProvider";
 
 export function InsightsSection() {
-  const { textContent } = useTextContent();
+  const { textContent, isEditing } = useTextContent();
   const insights = textContent.insights.articles;
 
   return (
@@ -33,50 +34,71 @@ export function InsightsSection() {
 
         <div className="grid md:grid-cols-3 gap-8">
           {insights.map((insight, index) => (
-            <article key={index} className="bg-slate-50 rounded-lg p-8 hover:shadow-lg transition-shadow cursor-pointer border border-slate-200">
-              <EditableText
-                path={`insights.articles.${index}.category`}
-                value={insight.category}
-                className="text-caption mb-3 uppercase tracking-wide"
-                style={{color: 'var(--blue-corporate)'}}
-              />
-              <EditableText
-                path={`insights.articles.${index}.title`}
-                value={insight.title}
-                as="h3"
-                className="text-card-title text-slate-900 mb-3"
-              />
-              <EditableText
-                path={`insights.articles.${index}.excerpt`}
-                value={insight.excerpt}
-                as="p"
-                className="text-body text-slate-600 mb-6"
-                multiline
-              />
-              
-              <div className="flex items-center justify-between text-caption text-slate-500">
-                <div className="flex items-center">
-                  <Calendar className="w-4 h-4 mr-2" />
-                  <EditableText
-                    path={`insights.articles.${index}.date`}
-                    value={insight.date}
-                  />
+            <Link
+              key={insight.slug}
+              to={`/insights/${insight.slug}`}
+              onClick={(event) => {
+                if (isEditing) {
+                  event.preventDefault();
+                }
+              }}
+              className="group block"
+            >
+              <article className="bg-slate-50 rounded-lg p-8 border border-slate-200 transition-shadow group-hover:shadow-lg">
+                <EditableText
+                  path={`insights.articles.${index}.category`}
+                  value={insight.category}
+                  className="text-caption mb-3 uppercase tracking-wide"
+                  style={{ color: "var(--blue-corporate)" }}
+                />
+                <EditableText
+                  path={`insights.articles.${index}.title`}
+                  value={insight.title}
+                  as="h3"
+                  className="text-card-title text-slate-900 mb-3"
+                />
+                <EditableText
+                  path={`insights.articles.${index}.excerpt`}
+                  value={insight.excerpt}
+                  as="p"
+                  className="text-body text-slate-600 mb-6"
+                  multiline
+                />
+
+                <div className="flex items-center justify-between text-caption text-slate-500">
+                  <div className="flex items-center">
+                    <Calendar className="w-4 h-4 mr-2" />
+                    <EditableText
+                      path={`insights.articles.${index}.date`}
+                      value={insight.date}
+                    />
+                  </div>
+                  <div>
+                    <EditableText
+                      path={`insights.articles.${index}.readTime`}
+                      value={insight.readTime}
+                    />
+                  </div>
                 </div>
-                <div>
-                  <EditableText
-                    path={`insights.articles.${index}.readTime`}
-                    value={insight.readTime}
-                  />
-                </div>
-              </div>
-            </article>
+              </article>
+            </Link>
           ))}
         </div>
 
         <div className="text-center mt-12">
-          <Button variant="outline">
-            View All Insights
-            <ArrowRight className="w-4 h-4 ml-2" />
+          <Button variant="outline" asChild>
+            <Link
+              to={insights.length ? `/insights/${insights[0].slug}` : "/"}
+              onClick={(event) => {
+                if (isEditing) {
+                  event.preventDefault();
+                }
+              }}
+              className="inline-flex items-center"
+            >
+              View All Insights
+              <ArrowRight className="w-4 h-4 ml-2" />
+            </Link>
           </Button>
         </div>
       </div>

--- a/src/components/MediaSection.tsx
+++ b/src/components/MediaSection.tsx
@@ -1,5 +1,5 @@
 import { ExternalLink, Award, FileText, Palette } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { ColorPicker } from "./ColorPicker";
 import { useSectionColors } from "./SectionColorProvider";
 import { EditableText } from "./EditableText";
@@ -8,34 +8,15 @@ import { useTextContent } from "./TextContentProvider";
 export function MediaSection() {
   const [showColorPicker, setShowColorPicker] = useState(false);
   const { colors, setColors } = useSectionColors('media', true);
-  const { textContent } = useTextContent();
-  
-  const mediaItems = [
-    {
-      type: "Press Release",
-      title: textContent.media.coverage[0].title,
-      source: textContent.media.coverage[0].publication,
-      date: textContent.media.coverage[0].date,
-      excerpt: textContent.media.coverage[0].excerpt,
-      icon: FileText
-    },
-    {
-      type: "Award",
-      title: textContent.media.coverage[1].title,
-      source: textContent.media.coverage[1].publication,
-      date: textContent.media.coverage[1].date,
-      excerpt: textContent.media.coverage[1].excerpt,
-      icon: Award
-    },
-    {
-      type: "Interview",
-      title: textContent.media.coverage[2].title,
-      source: textContent.media.coverage[2].publication,
-      date: textContent.media.coverage[2].date,
-      excerpt: textContent.media.coverage[2].excerpt,
-      icon: ExternalLink
-    }
-  ];
+  const { textContent, isEditing } = useTextContent();
+
+  const mediaItems = useMemo(() => {
+    const icons = [FileText, Award, ExternalLink];
+    return textContent.media.coverage.map((item, index) => ({
+      ...item,
+      icon: icons[index % icons.length]
+    }));
+  }, [textContent.media.coverage]);
 
   return (
     <>
@@ -85,13 +66,23 @@ export function MediaSection() {
           {mediaItems.map((item, index) => {
             const Icon = item.icon;
             return (
-              <div key={index} className="bg-white rounded-lg p-8 shadow-lg hover:shadow-xl transition-shadow cursor-pointer">
+              <a
+                key={item.url ?? index}
+                href={item.url || '#'}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={event => {
+                  if (isEditing || !item.url) {
+                    event.preventDefault();
+                  }
+                }}
+                className="block bg-white rounded-lg p-8 shadow-lg hover:shadow-xl transition-shadow"
+              >
                 <div className="flex items-start space-x-4">
                   <div className="w-12 h-12 rounded-lg flex items-center justify-center flex-shrink-0" style={{backgroundColor: 'var(--sky-cool)'}}>
                     <Icon className="w-6 h-6" style={{color: 'var(--blue-corporate)'}} />
                   </div>
                   <div className="flex-1 min-w-0">
-                    <div className="text-caption mb-2 uppercase tracking-wide" style={{color: 'var(--blue-corporate)'}}>{item.type}</div>
                     <EditableText
                       path={`media.coverage.${index}.title`}
                       value={item.title}
@@ -108,7 +99,7 @@ export function MediaSection() {
                     <div className="flex items-center justify-between text-caption text-slate-500">
                       <EditableText
                         path={`media.coverage.${index}.publication`}
-                        value={item.source}
+                        value={item.publication}
                       />
                       <EditableText
                         path={`media.coverage.${index}.date`}
@@ -117,7 +108,7 @@ export function MediaSection() {
                     </div>
                   </div>
                 </div>
-              </div>
+              </a>
             );
           })}
         </div>

--- a/src/components/TextContentProvider.tsx
+++ b/src/components/TextContentProvider.tsx
@@ -79,8 +79,10 @@ export interface TextContent {
     title: string;
     description: string;
     articles: {
+      slug: string;
       title: string;
       excerpt: string;
+      content: string;
       date: string;
       readTime: string;
       category: string;
@@ -96,6 +98,7 @@ export interface TextContent {
       publication: string;
       date: string;
       excerpt: string;
+      url: string;
     }[];
   };
   
@@ -267,22 +270,31 @@ const defaultTextContent: TextContent = {
     description: "Stay informed with our latest market analysis, industry insights, and thought leadership on technology investment trends.",
     articles: [
       {
+        slug: "future-of-b2b-saas",
         title: "The Future of B2B SaaS: Trends Shaping 2024",
         excerpt: "Exploring the key trends that will define the B2B software landscape, from AI integration to evolving customer expectations.",
+        content:
+          "B2B SaaS has entered a new maturity curve where vertical expertise outweighs horizontal feature sets. Buyers now expect products that solve industry-specific workflows, integrate with legacy data sources, and come with embedded analytics that shorten time-to-value. Founders that build deep partnerships with launch customers and co-design modules around regulated processes will continue to capture disproportionate market share.\n\nArtificial intelligence is shifting from a stand-alone capability to an operating principle. Instead of marketing AI as a differentiator, leading companies embed machine learning into onboarding, security, and customer success so users experience tangible productivity gains without retraining their teams. This requires disciplined data governance and model monitoring from day one—areas where Omnia Prime actively supports portfolio companies.\n\nFinally, the financing landscape is rewarding efficient growth. Investors prioritise net revenue retention, capital-light expansion strategies, and diversified go-to-market playbooks over headline ARR growth. Operators that master usage-based pricing, channel partnerships, and customer-led community building will outperform as the market normalises.",
         date: "March 15, 2024",
         readTime: "5 min read",
         category: "Market Analysis"
       },
       {
+        slug: "operational-excellence-in-high-growth",
         title: "Operational Excellence in High-Growth Startups",
         excerpt: "How portfolio companies can maintain operational efficiency while scaling rapidly in competitive markets.",
-        date: "March 8, 2024", 
+        content:
+          "Scaling companies often inherit the heroics of their founding teams—processes live in spreadsheets, vendor relationships depend on personal rapport, and institutional knowledge is rarely documented. The first step toward operational excellence is mapping critical workflows and deciding which ones require automation, outsourcing, or new leadership. Building a 90-day plan that clarifies decision rights, success metrics, and weekly operating cadences keeps execution on track even as headcount doubles.\n\nCommercial acceleration should happen in lockstep with operational upgrades. Implementing structured sales stages, revenue forecasting discipline, and post-sale handoffs enables teams to spot friction before it reaches customers. Paired with scenario-based financial planning, leadership can invest confidently in growth levers without overextending working capital.\n\nThe final ingredient is cultural. High-performing scale-ups promote continuous improvement rituals—retrospectives, cross-functional stand-ups, and transparent dashboards—that highlight bottlenecks early. Omnia Prime partners with founders to install these habits, ensuring that growth compounds instead of creating hidden fragility.",
+        date: "March 8, 2024",
         readTime: "7 min read",
         category: "Operations"
       },
       {
+        slug: "esg-integration-private-equity",
         title: "ESG Integration in Private Equity",
         excerpt: "Best practices for incorporating environmental, social, and governance factors into investment decisions.",
+        content:
+          "ESG integration begins before an investment memorandum is drafted. Sector screening must evaluate regulatory headwinds, resource intensity, and community impact alongside financial attractiveness. During due diligence, leading funds assess carbon baselines, workforce policies, and governance structures to quantify both risks and upside. These diagnostics set realistic improvement targets that can be embedded into shareholder agreements and management incentives.\n\nPost-close, ESG moves from policy to execution. Portfolio companies benefit from pragmatic roadmaps that blend quick wins—energy-efficiency audits, safety training refreshers, inclusive hiring frameworks—with longer-term initiatives such as supplier diversification and circular product design. Tracking progress requires consistent data collection and board-level review so ESG metrics carry the same weight as EBITDA and cash conversion.\n\nWhen executed with intent, ESG creates measurable enterprise value. Companies unlock cheaper financing, win contracts that mandate sustainability credentials, and retain talent that wants to work for responsible employers. Omnia Prime leverages its operating network to help founders capture these benefits while meeting institutional LP expectations.",
         date: "February 28, 2024",
         readTime: "6 min read",
         category: "ESG"
@@ -295,22 +307,81 @@ const defaultTextContent: TextContent = {
     description: "Recent coverage and recognition of Omnia Prime's investment approach and portfolio company successes.",
     coverage: [
       {
-        title: "Omnia Prime Leads €25M Series B in TechFlow",
-        publication: "European Private Equity",
-        date: "March 20, 2024",
-        excerpt: "Investment focuses on scaling TechFlow's AI-powered workflow automation platform across European markets."
+        title: "123Credit crește de cinci ori într-un an",
+        publication: "HotNews.ro",
+        date: "Accessed 2024",
+        excerpt: "HotNews.ro prezintă modul în care marketplace-ul 123Credit, susținut de Omnia Capital, a devenit liderul digital al creditării din România după o creștere accelerată.",
+        url: "https://hotnews.ro/123credit-creste-de-5-ori-intr-un-an-noul-lider-digital-al-creditarii-din-romania-2070591?utm"
       },
       {
-        title: "The Rise of Operational Private Equity in Europe",
-        publication: "Financial Times",
-        date: "March 12, 2024", 
-        excerpt: "Omnia Prime featured as a leading example of hands-on investment approach driving superior returns."
+        title: "Dumagas, companie din portofoliul Omnia Capital, intră pe segmentul auto",
+        publication: "Ziarul Financiar",
+        date: "Accessed 2024",
+        excerpt: "Ziarul Financiar relatează extinderea transportatorului Dumagas, preluat de Omnia Capital, către noi linii de business din zona auto.",
+        url: "https://www.zf.ro/auto/dumagas-preluata-in-urma-cu-doi-ani-de-omnia-capital-a-intrat-pe-22769406?utm"
       },
       {
-        title: "Sustainability in Tech Investments",
-        publication: "TechCrunch Europe",
-        date: "February 25, 2024",
-        excerpt: "How Omnia Prime integrates ESG principles into its investment thesis and portfolio management."
+        title: "Matei Ladea explică cum companiile românești pot accelera investițiile",
+        publication: "Ziarul Financiar",
+        date: "Accessed 2024",
+        excerpt: "Cofondatorul Omnia Capital, Matei Ladea, discută despre soluțiile prin care antreprenorii locali pot finanța planuri ambițioase de creștere.",
+        url: "https://www.zf.ro/companii/matei-ladea-omnia-capital-companiile-romanesti-pot-acum-investi-in-22779046?utm"
+      },
+      {
+        title: "Omnia Capital investește în platforma Cargo Buddy",
+        publication: "Profit.ro",
+        date: "Accessed 2024",
+        excerpt: "Profit.ro anunță preluarea unei participații la Cargo Buddy de către Omnia Capital pentru a accelera digitalizarea transporturilor.",
+        url: "https://www.profit.ro/povesti-cu-profit/auto-transporturi/tranzactie-omnia-capital-preia-o-parte-din-actiunile-cargo-buddy-platforma-lansata-de-mihai-nastase-21654638?utm"
+      },
+      {
+        title: "Dumagas, controlat de Omnia Capital, pariază pe extindere",
+        publication: "Ziarul Financiar",
+        date: "Accessed 2024",
+        excerpt: "Ziarul Financiar urmărește planurile de creștere ale transportatorului Dumagas după integrarea în portofoliul Omnia Capital.",
+        url: "https://www.zf.ro/companii/transportatorul-local-dumagas-controlat-omnia-capital-pariaza-22167552?utm"
+      },
+      {
+        title: "ZF Live: Matei Ladea despre strategia Omnia Capital",
+        publication: "Ziarul Financiar",
+        date: "Accessed 2024",
+        excerpt: "Matei Ladea, cofondator Omnia Capital, explică la ZF Live modul în care fondul urmărește companii românești cu potențial regional.",
+        url: "https://www.zf.ro/companii/zf-live-matei-ladea-cofondator-omnia-capital-ne-uitat-900-companii-21779125?utm"
+      },
+      {
+        title: "Omnia Capital preia Dumagas de la Bancroft",
+        publication: "CEE Legal Matters",
+        date: "Accessed 2024",
+        excerpt: "CEE Legal Matters analizează achiziția Dumagas de către Omnia Capital și implicarea echipei juridice în tranzacție.",
+        url: "https://ceelegalmatters.com/deal-5/22871-deal-5-omnia-chief-evangelist-matei-ladea-on-dumagas-acquisition-from-bancroft?utm"
+      },
+      {
+        title: "15 minute cu un antreprenor: Matei Ladea",
+        publication: "Ziarul Financiar",
+        date: "Accessed 2024",
+        excerpt: "Interviul ZF 15 minute cu Matei Ladea explorează parcursul Omnia Capital și filosofia de parteneriat cu fondatorii.",
+        url: "https://www.zf.ro/zf-15-minute-cu-un-antreprenor/zf-15-minute-cu-un-antreprenor-matei-ladea-cofondator-al-omnia-20778656?utm"
+      },
+      {
+        title: "123credit.ro ridică 3 milioane de euro cu sprijinul Omnia Capital",
+        publication: "Profit.ro",
+        date: "Accessed 2024",
+        excerpt: "Profit.ro detaliază runda de finanțare prin care Omnia Capital susține extinderea platformei 123credit.ro.",
+        url: "https://www.profit.ro/povesti-cu-profit/startup-ul-123credit-ro-a-obtinut-o-finantare-de-3-milioane-de-euro-prin-intermediul-omnia-capital-in-a-doua-runda-de-finantare-20851209?utm"
+      },
+      {
+        title: "Omnia Capital finalizează preluarea Dumagas",
+        publication: "Romania Insider",
+        date: "Accessed 2024",
+        excerpt: "Romania Insider anunță finalizarea tranzacției prin care Omnia Capital a preluat transportatorul Dumagas.",
+        url: "https://www.romania-insider.com/omnia-capital-dumagas-takeover-2023?utm"
+      },
+      {
+        title: "Fondatorii Omnia Capital discută achiziția Dumagas",
+        publication: "ZF Investiți în România",
+        date: "Accessed 2024",
+        excerpt: "Emisiunea ZF Investiți în România prezintă planurile fondatorilor Omnia Capital după achiziția transportatorului Dumagas.",
+        url: "https://www.zf.ro/zf-investiti-in-romania/zf-investiti-in-romania-fondatorii-companiei-care-a-preluat-dumagas-22344218?utm"
       }
     ]
   },

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,12 @@
 
-  import { createRoot } from "react-dom/client";
-  import App from "./App.tsx";
-  import "./index.css";
+import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import App from "./App.tsx";
+import "./index.css";
 
-  createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>
+);
   

--- a/src/pages/InsightArticlePage.tsx
+++ b/src/pages/InsightArticlePage.tsx
@@ -1,0 +1,95 @@
+import { ArrowLeft, Calendar, Clock } from "lucide-react";
+import { Link, useParams } from "react-router-dom";
+import { EditableText } from "../components/EditableText";
+import { useTextContent } from "../components/TextContentProvider";
+
+export function InsightArticlePage() {
+  const { slug } = useParams<{ slug: string }>();
+  const { textContent } = useTextContent();
+
+  const articleIndex = textContent.insights.articles.findIndex(
+    (article) => article.slug === slug
+  );
+
+  if (articleIndex === -1) {
+    return (
+      <section className="py-20 bg-slate-50">
+        <div className="max-w-3xl mx-auto px-4">
+          <p className="text-lg text-slate-700 mb-6">
+            The requested insight could not be found.
+          </p>
+          <Link
+            to="/"
+            className="inline-flex items-center text-blue-600 hover:text-blue-700 font-medium"
+          >
+            <ArrowLeft className="w-4 h-4 mr-2" />
+            Return to insights overview
+          </Link>
+        </div>
+      </section>
+    );
+  }
+
+  const article = textContent.insights.articles[articleIndex];
+
+  return (
+    <article className="py-20 bg-slate-50">
+      <div className="max-w-3xl mx-auto px-4">
+        <Link
+          to="/"
+          className="inline-flex items-center text-blue-600 hover:text-blue-700 font-medium mb-8"
+        >
+          <ArrowLeft className="w-4 h-4 mr-2" />
+          Back to insights overview
+        </Link>
+
+        <EditableText
+          path={`insights.articles.${articleIndex}.category`}
+          value={article.category}
+          className="text-sm uppercase tracking-wide text-blue-600 mb-4 block"
+        />
+
+        <EditableText
+          path={`insights.articles.${articleIndex}.title`}
+          value={article.title}
+          as="h1"
+          className="text-4xl font-semibold text-slate-900 leading-tight mb-6"
+        />
+
+        <div className="flex flex-wrap items-center gap-6 text-sm text-slate-500 mb-10">
+          <span className="inline-flex items-center">
+            <Calendar className="w-4 h-4 mr-2" />
+            <EditableText
+              path={`insights.articles.${articleIndex}.date`}
+              value={article.date}
+            />
+          </span>
+          <span className="inline-flex items-center">
+            <Clock className="w-4 h-4 mr-2" />
+            <EditableText
+              path={`insights.articles.${articleIndex}.readTime`}
+              value={article.readTime}
+            />
+          </span>
+        </div>
+
+        <EditableText
+          path={`insights.articles.${articleIndex}.excerpt`}
+          value={article.excerpt}
+          as="p"
+          className="text-xl text-slate-700 mb-10"
+          multiline
+        />
+
+        <EditableText
+          path={`insights.articles.${articleIndex}.content`}
+          value={article.content}
+          as="div"
+          className="prose prose-lg max-w-none text-slate-700 [&>p]:mb-6"
+          style={{ whiteSpace: "pre-line" }}
+          multiline
+        />
+      </div>
+    </article>
+  );
+}


### PR DESCRIPTION
## Summary
- extend media coverage entries with external URLs and new press stories
- render media cards as outbound links while respecting edit mode interactions

## Testing
- npm install *(fails: npm registry access returns 403 in this environment)*
- npm run build *(fails: vite not found before installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c0fb4710832096cdca0696cd7c26